### PR TITLE
feat: CPU プレイヤー(ランダム挙動)対応

### DIFF
--- a/packages/client/src/api.ts
+++ b/packages/client/src/api.ts
@@ -76,3 +76,16 @@ export async function startGame(roomId: string): Promise<void> {
     method: "POST",
   })
 }
+
+export type AddCpuResult = { added: string[] }
+
+export async function addCpuPlayers(
+  roomId: string,
+  body: { count?: number; fill?: boolean } = {},
+): Promise<AddCpuResult> {
+  const res = await request(`/rooms/${encodeURIComponent(roomId)}/cpu-players`, {
+    method: "POST",
+    body: JSON.stringify(body),
+  })
+  return res.json()
+}

--- a/packages/client/src/components/Lobby.tsx
+++ b/packages/client/src/components/Lobby.tsx
@@ -52,12 +52,17 @@ export function Lobby() {
   // 4 席ぶんを seat_index 順で構築(view.turnOrder は ゲーム開始まで空なので、self/others の組合せで埋める)
   const seats: SeatData[] = useMemo(() => {
     const out: SeatData[] = []
-    const ordered: { id: string; name: string; online: boolean }[] = []
+    const ordered: { id: string; name: string; online: boolean; isCpu: boolean }[] = []
     if (view?.self) {
-      ordered.push({ id: view.self.id, name: view.self.name, online: view.self.online })
+      ordered.push({
+        id: view.self.id,
+        name: view.self.name,
+        online: view.self.online,
+        isCpu: view.self.isCpu,
+      })
     }
     view?.others.forEach((o) => {
-      ordered.push({ id: o.id, name: o.name, online: o.online })
+      ordered.push({ id: o.id, name: o.name, online: o.online, isCpu: o.isCpu })
     })
     for (let i = 0; i < NUM_PLAYERS; i++) {
       const p = ordered[i]
@@ -67,6 +72,7 @@ export function Lobby() {
         isHost: p ? p.id === view?.hostPlayerId : false,
         isYou: p ? p.id === view?.self?.id : false,
         online: p?.online ?? true,
+        isCpu: p?.isCpu ?? false,
       })
     }
     return out
@@ -85,6 +91,15 @@ export function Lobby() {
   const handleBack = () => {
     disconnectSocket()
     leaveRoom()
+  }
+
+  const handleAddCpu = async (fill: boolean) => {
+    if (!roomId) return
+    try {
+      await api.addCpuPlayers(roomId, fill ? { fill: true } : { count: 1 })
+    } catch (e) {
+      alert(`CPU 追加失敗: ${(e as Error).message}`)
+    }
   }
 
   const startBtn = (() => {
@@ -251,6 +266,29 @@ export function Lobby() {
             {!isHost && " 主催者の開始を待っています…"}
           </div>
         </SBox>
+      )}
+
+      {isHost && !allReady && alreadyJoined && (
+        <div style={{ marginTop: 14, display: "flex", gap: 8 }}>
+          <SBtn
+            bg={PAPER}
+            color={INK}
+            size="md"
+            onClick={() => handleAddCpu(false)}
+            style={{ flex: 1 }}
+          >
+            + CPU 1人
+          </SBtn>
+          <SBtn
+            bg={ACCENT_BLUE}
+            color={PAPER}
+            size="md"
+            onClick={() => handleAddCpu(true)}
+            style={{ flex: 1 }}
+          >
+            残り席を CPU で埋める
+          </SBtn>
+        </div>
       )}
 
       <div style={{ marginTop: 24 }}>{startBtn}</div>

--- a/packages/client/src/sketch/Seat.tsx
+++ b/packages/client/src/sketch/Seat.tsx
@@ -17,6 +17,7 @@ export type SeatData = {
   isHost: boolean
   isYou: boolean
   online: boolean
+  isCpu: boolean
 }
 
 type Props = {
@@ -77,6 +78,20 @@ export function Seat({ seat, ready }: Props) {
                   }}
                 >
                   HOST
+                </div>
+              )}
+              {seat.isCpu && (
+                <div
+                  style={{
+                    fontFamily: FONT_MONO,
+                    fontSize: 9,
+                    padding: "1px 5px",
+                    background: INK_SOFT,
+                    color: PAPER,
+                    borderRadius: 2,
+                  }}
+                >
+                  CPU
                 </div>
               )}
             </div>

--- a/packages/server/drizzle/0009_room_players_is_cpu.sql
+++ b/packages/server/drizzle/0009_room_players_is_cpu.sql
@@ -1,0 +1,3 @@
+-- CPU プレイヤー識別用に room_players.is_cpu を追加
+ALTER TABLE "room_players"
+  ADD COLUMN IF NOT EXISTS "is_cpu" boolean NOT NULL DEFAULT false;

--- a/packages/server/drizzle/meta/_journal.json
+++ b/packages/server/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1700000008000,
       "tag": "0008_drop_passphrase",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1700000009000,
+      "tag": "0009_room_players_is_cpu",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/src/db/repository.ts
+++ b/packages/server/src/db/repository.ts
@@ -54,6 +54,7 @@ export async function loadRoomState(tx: Tx, roomId: string): Promise<GameState |
       fakesUsed: rp.fakesUsed,
       passed: rp.passed,
       online: rp.online,
+      isCpu: rp.isCpu,
     }
   })
 
@@ -120,6 +121,7 @@ export async function saveRoomState(tx: Tx, state: GameState, roomId: string): P
       fakesUsed: p.fakesUsed,
       passed: p.passed,
       online: p.online,
+      isCpu: p.isCpu,
       seatIndex: index,
     }))
     await tx.insert(roomPlayers).values(roomPlayerRows)

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -32,6 +32,7 @@ export const roomPlayers = pgTable(
     fakesUsed: integer("fakes_used").notNull().default(0),
     passed: boolean("passed").notNull().default(false),
     online: boolean("online").notNull().default(true),
+    isCpu: boolean("is_cpu").notNull().default(false),
     seatIndex: integer("seat_index").notNull(),
   },
   (table) => ({

--- a/packages/server/src/gameEngine.ts
+++ b/packages/server/src/gameEngine.ts
@@ -84,6 +84,7 @@ export function addPlayer(state: GameState, id: PlayerId, name: string): EngineR
     fakesUsed: 0,
     passed: false,
     online: true,
+    isCpu: false,
   })
 
   // 初参加者をホストに確定(以降不変)
@@ -94,9 +95,31 @@ export function addPlayer(state: GameState, id: PlayerId, name: string): EngineR
   return ok([{ type: "view-update" }])
 }
 
+// CPU プレイヤーを 1 体追加。playerId は呼び出し側で UUID を生成して渡す
+export function addCpuPlayer(state: GameState, id: PlayerId, name: string): EngineResult {
+  if (state.phase !== "lobby") return err("not-lobby", "ゲーム進行中は CPU 追加不可")
+  if (state.players.length >= NUM_PLAYERS) return err("full", "定員到達")
+  if (state.players.some((p) => p.id === id)) return err("duplicate", "ID 重複")
+
+  state.players.push({
+    id,
+    name,
+    brand: BRANDS[0]!,
+    hand: [],
+    cash: 0,
+    fakesUsed: 0,
+    passed: false,
+    online: true,
+    isCpu: true,
+  })
+  return ok([{ type: "view-update" }])
+}
+
 export function markOffline(state: GameState, id: PlayerId): EngineResult {
   const player = state.players.find((p) => p.id === id)
   if (!player) return ok([])
+  // CPU はクライアント接続を持たないため切断対象外
+  if (player.isCpu) return ok([])
 
   // ロビー中は即離脱(他の人が参加できるように)
   if (state.phase === "lobby") {
@@ -286,4 +309,64 @@ function settleAuction(state: GameState): EngineResult {
   state.phase = "listing"
   events.push({ type: "view-update" })
   return ok(events)
+}
+
+function pickRandom<T>(arr: readonly T[]): T {
+  return arr[Math.floor(Math.random() * arr.length)]!
+}
+
+// 現在のターン担当の CPU が存在すれば、その CPU の playerId を返す
+export function findActiveCpu(state: GameState): Player | null {
+  if (state.phase !== "listing" && state.phase !== "bidding") return null
+  if (state.turnOrder.length === 0) return null
+  if (state.phase === "listing") {
+    const sellerId = state.turnOrder[state.turnIndex]
+    if (!sellerId) return null
+    const seller = getPlayer(state, sellerId)
+    return seller && seller.isCpu ? seller : null
+  }
+  // bidding: 出品者以外で未パス・所持金あり・CPU を順に検索
+  const auction = state.currentAuction
+  if (!auction) return null
+  for (const p of state.players) {
+    if (!p.isCpu) continue
+    if (p.id === auction.sellerId) continue
+    if (auction.passedPlayerIds.includes(p.id)) continue
+    return p
+  }
+  return null
+}
+
+// CPU が現在のフェーズに対して取るべき 1 アクションを実行する。
+// state を直接更新し、発生した EngineEvent を返す。
+// 呼び出し側はループで findActiveCpu と組み合わせて使う想定。
+export function cpuActOnce(state: GameState): EngineResult {
+  const cpu = findActiveCpu(state)
+  if (!cpu) return ok([])
+
+  if (state.phase === "listing") {
+    if (cpu.hand.length === 0) return err("cpu-no-hand", "CPU 手札が空")
+    const card = pickRandom(cpu.hand)
+    const fakeRemaining = MAX_FAKES_PER_PLAYER - cpu.fakesUsed
+    const allowedBrands = fakeRemaining > 0 ? BRANDS : ([cpu.brand] as readonly Brand[])
+    const declaredBrand = pickRandom(allowedBrands)
+    // 開始額: 0..min(10, cash) の小さめのランダム値
+    const cap = Math.min(10, cpu.cash)
+    const startingBid = cap > 0 ? Math.floor(Math.random() * (cap + 1)) : 0
+    return listCard(state, cpu.id, card.id, declaredBrand, startingBid)
+  }
+
+  if (state.phase === "bidding") {
+    const auction = state.currentAuction!
+    const minAmount =
+      auction.highestBidderId === null ? auction.startingBid : auction.currentBid + 1
+    // 所持金不足は必ず pass
+    if (minAmount > cpu.cash) return pass(state, cpu.id)
+    // 60% で最低額に上乗せ、40% で pass
+    const willBid = Math.random() < 0.6
+    if (!willBid) return pass(state, cpu.id)
+    return bid(state, cpu.id, minAmount)
+  }
+
+  return ok([])
 }

--- a/packages/server/src/http/rooms.ts
+++ b/packages/server/src/http/rooms.ts
@@ -1,16 +1,17 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify"
 import { and, eq, ne } from "drizzle-orm"
-import { generateUuid } from "@bluff-auction/shared"
+import { NUM_PLAYERS, generateUuid } from "@bluff-auction/shared"
 import { loadRoomState, saveRoomState } from "../db/repository.js"
 import { withTx, db } from "../db/client.js"
 import { players, rooms } from "../db/schema.js"
-import { addPlayer, removePlayer, startGame } from "../gameEngine.js"
+import { addCpuPlayer, addPlayer, removePlayer, startGame } from "../gameEngine.js"
 import { buildView } from "../viewFilter.js"
 import type { EngineEvent } from "../gameEngine.js"
 
 type RoomOpsDeps = {
   broadcastViews: (roomId: string) => Promise<void>
   dispatchEngineEvents: (events: EngineEvent[], roomId: string) => Promise<void>
+  scheduleCpuTurn: (roomId: string) => void
 }
 
 const UUID_REGEX = /^[0-9a-f]{32}$/
@@ -203,6 +204,88 @@ export async function registerRoomRoutes(app: FastifyInstance, deps: RoomOpsDeps
     },
   )
 
+  // CPU プレイヤー追加(ホストのみ・ロビーのみ)
+  app.post<{ Params: { id: string }; Body: { count?: number; fill?: boolean } }>(
+    "/rooms/:id/cpu-players",
+    {
+      schema: {
+        tags: ["rooms"],
+        summary: "CPU プレイヤーを追加(ホストのみ)",
+        params: {
+          type: "object",
+          properties: { id: { type: "string" } },
+          required: ["id"],
+        },
+        headers: {
+          type: "object",
+          properties: { "x-player-id": { type: "string" } },
+          required: ["x-player-id"],
+        },
+        body: {
+          type: "object",
+          properties: {
+            count: { type: "integer", minimum: 1, maximum: NUM_PLAYERS },
+            fill: { type: "boolean" },
+          },
+          additionalProperties: false,
+        },
+      },
+    },
+    async (req, reply) => {
+      const playerId = requirePlayerId(req, reply)
+      if (!playerId) return
+      const roomId = resolveRoomIdParam(req.params.id, reply)
+      if (!roomId) return
+
+      const result = await withTx(async (tx) => {
+        const s = await loadRoomState(tx, roomId)
+        if (!s) return { kind: "not-found" as const }
+        if (s.phase !== "lobby")
+          return {
+            kind: "engine-error" as const,
+            code: "not-lobby",
+            message: "ロビー以外で追加不可",
+          }
+        if (s.hostPlayerId !== playerId)
+          return { kind: "engine-error" as const, code: "not-host", message: "ホストのみ追加可能" }
+
+        const remaining = NUM_PLAYERS - s.players.length
+        if (remaining <= 0)
+          return { kind: "engine-error" as const, code: "full", message: "定員到達" }
+
+        const requested = req.body?.fill ? remaining : Math.max(1, req.body?.count ?? 1)
+        const toAdd = Math.min(requested, remaining)
+
+        const addedIds: string[] = []
+        for (let i = 0; i < toAdd; i++) {
+          const cpuId = generateUuid()
+          // 名前は「CPU N」(席順は seat_index で別途決まる)
+          const cpuName = `CPU ${s.players.length + 1}`
+          // CPU 名は room_players には書かれず players マスターに保存される
+          await tx.insert(players).values({ id: cpuId, name: cpuName }).onConflictDoNothing()
+          const res = addCpuPlayer(s, cpuId, cpuName)
+          if (!res.ok)
+            return { kind: "engine-error" as const, code: res.code, message: res.message }
+          addedIds.push(cpuId)
+        }
+        await saveRoomState(tx, s, roomId)
+        return { kind: "ok" as const, addedIds }
+      })
+
+      if (result.kind === "not-found") {
+        reply.code(404).send({ code: "not-found", message: "ルームが存在しない" })
+        return
+      }
+      if (result.kind === "engine-error") {
+        const status = result.code === "not-host" ? 403 : 400
+        reply.code(status).send({ code: result.code, message: result.message })
+        return
+      }
+      await deps.broadcastViews(roomId)
+      reply.code(201).send({ added: result.addedIds })
+    },
+  )
+
   // ゲーム開始(ホストのみ)
   app.post<{ Params: { id: string } }>(
     "/rooms/:id/start",
@@ -249,6 +332,8 @@ export async function registerRoomRoutes(app: FastifyInstance, deps: RoomOpsDeps
         return
       }
       await deps.dispatchEngineEvents(result.events, roomId)
+      // 開始直後の最初の出品者が CPU の場合に備え、自動進行をキック
+      deps.scheduleCpuTurn(roomId)
       reply.code(204).send()
     },
   )

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -11,6 +11,8 @@ import type {
 } from "@bluff-auction/shared"
 import {
   bid,
+  cpuActOnce,
+  findActiveCpu,
   listCard,
   markOffline,
   pass,
@@ -116,9 +118,43 @@ async function main() {
     dispatchEvents(events, state, roomId)
   }
 
+  // 現手番が CPU の場合に自動進行(setTimeout で軽くディレイ)
+  // すでにスケジュール済みのループとの多重実行を避けるためルーム単位でフラグ管理
+  const cpuLoopRunning = new Set<string>()
+  function scheduleCpuTurn(roomId: string): void {
+    if (cpuLoopRunning.has(roomId)) return
+    cpuLoopRunning.add(roomId)
+    setTimeout(() => {
+      cpuLoopRunning.delete(roomId)
+      void runCpuTurn(roomId)
+    }, 600)
+  }
+  async function runCpuTurn(roomId: string): Promise<void> {
+    try {
+      const result = await withTx(async (tx) => {
+        const s = await loadRoomState(tx, roomId)
+        if (!s) return null
+        if (!findActiveCpu(s)) return null
+        const res = cpuActOnce(s)
+        if (res.ok) await saveRoomState(tx, s, roomId)
+        return { result: res, state: s }
+      })
+      if (!result) return
+      if (result.result.ok) {
+        dispatchEvents(result.result.events, result.state, roomId)
+        // 次の手番もまた CPU なら続けて発火
+        if (findActiveCpu(result.state)) scheduleCpuTurn(roomId)
+      } else {
+        console.error("[server] cpu act error", result.result.code, result.result.message)
+      }
+    } catch (e) {
+      console.error("[server] cpu turn error", e)
+    }
+  }
+
   // REST ルート
   await registerPlayerRoutes(app)
-  await registerRoomRoutes(app, { broadcastViews, dispatchEngineEvents })
+  await registerRoomRoutes(app, { broadcastViews, dispatchEngineEvents, scheduleCpuTurn })
 
   function ackFromResult(result: EngineResult): AckResponse {
     return result.ok ? { ok: true } : { ok: false, code: result.code, message: result.message }
@@ -184,7 +220,10 @@ async function main() {
           ack?.({ ok: false, code: "not-found", message: "ルームが存在しない" })
           return
         }
-        if (result.result.ok) dispatchEvents(result.result.events, result.state, roomId)
+        if (result.result.ok) {
+          dispatchEvents(result.result.events, result.state, roomId)
+          scheduleCpuTurn(roomId)
+        }
         ack?.(ackFromResult(result.result))
       } catch (e) {
         console.error("[server] list-card error", e)
@@ -205,7 +244,10 @@ async function main() {
           ack?.({ ok: false, code: "not-found", message: "ルームが存在しない" })
           return
         }
-        if (result.result.ok) dispatchEvents(result.result.events, result.state, roomId)
+        if (result.result.ok) {
+          dispatchEvents(result.result.events, result.state, roomId)
+          scheduleCpuTurn(roomId)
+        }
         ack?.(ackFromResult(result.result))
       } catch (e) {
         console.error("[server] bid error", e)
@@ -226,7 +268,10 @@ async function main() {
           ack?.({ ok: false, code: "not-found", message: "ルームが存在しない" })
           return
         }
-        if (result.result.ok) dispatchEvents(result.result.events, result.state, roomId)
+        if (result.result.ok) {
+          dispatchEvents(result.result.events, result.state, roomId)
+          scheduleCpuTurn(roomId)
+        }
         ack?.(ackFromResult(result.result))
       } catch (e) {
         console.error("[server] pass error", e)

--- a/packages/server/src/viewFilter.ts
+++ b/packages/server/src/viewFilter.ts
@@ -16,6 +16,7 @@ function toPublicPlayer(p: GameState["players"][number]): PublicPlayerView {
     handCount: p.hand.length,
     passed: p.passed,
     online: p.online,
+    isCpu: p.isCpu,
   }
 }
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -22,6 +22,7 @@ export type Player = {
   fakesUsed: number
   passed: boolean
   online: boolean
+  isCpu: boolean
 }
 
 export type Auction = {
@@ -52,6 +53,7 @@ export type PublicPlayerView = {
   handCount: number
   passed: boolean
   online: boolean
+  isCpu: boolean
 }
 
 export type SelfPlayerView = PublicPlayerView & {


### PR DESCRIPTION
## Summary
- closes #5
- ロビーで CPU を追加可能(残席を一括で埋める fill オプションあり)
- 4 人(実プレイヤー + CPU)揃えば通常通り `startGame`
- CPU の手番はサーバー側で自動進行(setTimeout 600ms)
  - listing: 手札ランダム + 宣言ブランドランダム(フェイク残量に応じて自分のブランドに固定)+ 開始額 0..min(10, cash)
  - bidding: 60% で最低額に +1 入札、40% で pass、所持金不足は必ず pass
- CPU は `markOffline` の対象外(切断概念なし)
- DB に `room_players.is_cpu` を追加(migration 0009)
- shared: `Player.isCpu` / `PublicPlayerView.isCpu` を追加
- ロビー画面に「+ CPU 1人」「残り席を CPU で埋める」ボタンを追加。Seat に CPU バッジを表示

## API
新規エンドポイント:
- `POST /rooms/:id/cpu-players`
  - body: `{ count?: number; fill?: boolean }`
  - 成功時 201 `{ added: string[] }`
  - ホスト権限 + ロビー時のみ許可

## Test plan
- [ ] DB マイグレーション 0009 適用 (`make db-migrate`)
- [ ] 1人参加 → CPU を 3人追加 → 開始 → CPU が自動で listing / bid / pass
- [ ] CPU が出品権者の場合の自動 listCard
- [ ] CPU が入札権者の場合の bid / pass(所持金不足時に pass されること)
- [ ] フェイク残量 0 の CPU が必ず自分のブランドを宣言
- [ ] make ox / typecheck 通過