### PR TITLE
feat(client): WebSocket 再接続・リロード復帰対応

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react"
-import { socket } from "./socket.js"
+import { connectSocket, socket } from "./socket.js"
 import { useStore } from "./store.js"
 import { Lobby } from "./components/lobby/Lobby.js"
 import { AuctionBoard } from "./components/auction/AuctionBoard.js"
@@ -12,6 +12,7 @@ import { Rules } from "./components/rules/Rules.js"
 import { RulesLauncher } from "./components/RulesLauncher.js"
 import * as api from "./api.js"
 import { clearPlayerStorage, getStoredPlayerId } from "./utils/playerId.js"
+import { clearStoredRoomId, getStoredRoomId } from "./utils/roomId.js"
 
 type AuthStatus = "loading" | "missing" | "verified" | "error"
 
@@ -21,6 +22,7 @@ export function App() {
   const lobbyMode = useStore((s) => s.lobbyMode)
   const view = useStore((s) => s.view)
   const setUserName = useStore((s) => s.setUserName)
+  const setRoomId = useStore((s) => s.setRoomId)
   const setView = useStore((s) => s.setView)
   const setRevealed = useStore((s) => s.setRevealed)
   const setWinner = useStore((s) => s.setWinner)
@@ -63,6 +65,36 @@ export function App() {
       cancelled = true
     }
   }, [retryNonce, setUserName])
+
+  // 起動時の roomId 復帰フロー
+  useEffect(() => {
+    if (authStatus !== "verified") return
+    if (roomId) return
+    const stored = getStoredRoomId()
+    if (!stored) return
+    let cancelled = false
+    const run = async () => {
+      try {
+        const v = await api.getRoom(stored)
+        if (cancelled) return
+        if (v.phase === "ended") {
+          clearStoredRoomId()
+          return
+        }
+        setRoomId(stored)
+        connectSocket(stored)
+      } catch (e) {
+        if (cancelled) return
+        if (e instanceof api.HttpError && e.status === 404) {
+          clearStoredRoomId()
+        }
+      }
+    }
+    run()
+    return () => {
+      cancelled = true
+    }
+  }, [authStatus, roomId, setRoomId])
 
   // Socket イベント購読
   useEffect(() => {

--- a/packages/client/src/api.ts
+++ b/packages/client/src/api.ts
@@ -1,3 +1,4 @@
+import type { GameView } from "@bluff-auction/shared"
 import { getStoredPlayerId } from "./utils/playerId.js"
 
 const SERVER_URL = import.meta.env.VITE_SERVER_URL ?? "http://localhost:4000"
@@ -56,6 +57,11 @@ export type CreatedRoom = { id: string }
 
 export async function createRoom(): Promise<CreatedRoom> {
   const res = await request("/rooms", { method: "POST" })
+  return res.json()
+}
+
+export async function getRoom(roomId: string): Promise<GameView> {
+  const res = await request(`/rooms/${encodeURIComponent(roomId)}`)
   return res.json()
 }
 

--- a/packages/client/src/socket.ts
+++ b/packages/client/src/socket.ts
@@ -6,6 +6,10 @@ const SERVER_URL = import.meta.env.VITE_SERVER_URL ?? "http://localhost:4000"
 
 export const socket: Socket<ServerToClientEvents, ClientToServerEvents> = io(SERVER_URL, {
   autoConnect: false,
+  reconnection: true,
+  reconnectionAttempts: Infinity,
+  reconnectionDelay: 500,
+  reconnectionDelayMax: 5000,
 })
 
 export function connectSocket(roomId: string): void {

--- a/packages/client/src/store.ts
+++ b/packages/client/src/store.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand"
 import type { Brand, GameView, PlayerId } from "@bluff-auction/shared"
+import { clearStoredRoomId, setStoredRoomId } from "./utils/roomId.js"
 
 type RevealedCard = { brand: Brand }
 
@@ -32,13 +33,18 @@ export const useStore = create<State>((set) => ({
   lastError: null,
   winnerId: null,
   setUserName: (name) => set({ userName: name }),
-  setRoomId: (id) => set({ roomId: id }),
+  setRoomId: (id) => {
+    if (id) setStoredRoomId(id)
+    else clearStoredRoomId()
+    set({ roomId: id })
+  },
   setLobbyMode: (mode) => set({ lobbyMode: mode }),
   setView: (v) => set({ view: v }),
   setRevealed: (r) => set({ lastRevealed: r }),
   setError: (m) => set({ lastError: m }),
   setWinner: (id) => set({ winnerId: id }),
-  leaveRoom: () =>
+  leaveRoom: () => {
+    clearStoredRoomId()
     set({
       roomId: null,
       lobbyMode: "idle",
@@ -46,5 +52,6 @@ export const useStore = create<State>((set) => ({
       lastRevealed: null,
       lastError: null,
       winnerId: null,
-    }),
+    })
+  },
 }))

--- a/packages/client/src/utils/roomId.ts
+++ b/packages/client/src/utils/roomId.ts
@@ -1,0 +1,25 @@
+const ROOM_ID_KEY = "bluff-auction.roomId"
+
+export function getStoredRoomId(): string | null {
+  try {
+    return localStorage.getItem(ROOM_ID_KEY)
+  } catch {
+    return null
+  }
+}
+
+export function setStoredRoomId(id: string): void {
+  try {
+    localStorage.setItem(ROOM_ID_KEY, id)
+  } catch {
+    // noop
+  }
+}
+
+export function clearStoredRoomId(): void {
+  try {
+    localStorage.removeItem(ROOM_ID_KEY)
+  } catch {
+    // noop
+  }
+}


### PR DESCRIPTION
## Summary
- `roomId` を localStorage に永続化し、リロード後も自動で同じルームの画面に復帰
- 起動時に `GET /rooms/:id` で存在確認し、404 / ended の場合は localStorage をクリアして Home へ遷移
- `socket.io-client` の自動再接続(`reconnection: true`, `reconnectionAttempts: Infinity` 等)を明示的に有効化

Closes #6

## 変更ファイル
- `packages/client/src/utils/roomId.ts`(新規): localStorage の get/set/clear ヘルパ
- `packages/client/src/store.ts`: `setRoomId` / `leaveRoom` で localStorage を同期
- `packages/client/src/socket.ts`: 再接続オプションを設定
- `packages/client/src/api.ts`: `getRoom(roomId)` を追加
- `packages/client/src/App.tsx`: `authStatus === "verified"` 後に復帰フローを起動

## Test plan
- [ ] ロビー入室後にリロード → 同じルームの Lobby に戻る
- [ ] ゲーム中にリロード → 同じルームの GameBoard に戻り、手札・所持金・フェーズが復元される
- [ ] ゲーム終了後にリロード → localStorage がクリアされ Home に戻る
- [ ] 存在しない roomId が localStorage にある状態でリロード → Home に戻る
- [ ] ネットワーク瞬断後 → socket が自動再接続し、`view-update` で状態が同期される

🤖 Generated with [Claude Code](https://claude.com/claude-code)